### PR TITLE
Remove Net 6 Support

### DIFF
--- a/NuGet/Cotecna.Domain.Core.Configuration/Cotecna.Domain.Core.Configuration.csproj
+++ b/NuGet/Cotecna.Domain.Core.Configuration/Cotecna.Domain.Core.Configuration.csproj
@@ -26,7 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/NuGet/Cotecna.Domain.Core.Configuration/Cotecna.Domain.Core.Configuration.csproj
+++ b/NuGet/Cotecna.Domain.Core.Configuration/Cotecna.Domain.Core.Configuration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<PackageId>Cotecna.Domain.Core.Configuration</PackageId>
 		<AssemblyName>Cotecna.Domain.Core.Configuration</AssemblyName>
 		<RootNamespace>Cotecna.Domain.Core</RootNamespace>
@@ -10,20 +10,16 @@
 		<Authors>Cotecna Inspection</Authors>
 		<Company>Cotecna Inspection</Company>
 		<RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-		<Version>3.1.0</Version>
-		<FileVersion>3.1.0</FileVersion>
-		<AssemblyVersion>3.1.0</AssemblyVersion>
+		<Version>4.0.0</Version>
+		<FileVersion>4.0.0</FileVersion>
+		<AssemblyVersion>4.0.0</AssemblyVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageProjectUrl>https://github.com/Cotecna-Inspection/Domain.Core</PackageProjectUrl>
 		<PackageReleaseNotes>https://github.com/Cotecna-Inspection/Domain.Core/blob/main/NuGet/Cotecna.Domain.Core.Configuration/changelog.md</PackageReleaseNotes>
 		<RepositoryUrl>https://github.com/Cotecna-Inspection/Domain.Core.git</RepositoryUrl>
 		<RepositoryType>GIT</RepositoryType>
 		<PackageTags>Utilities;Helpers;Common;Core;DDD;Domain</PackageTags>
-	</PropertyGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-	</ItemGroup>
+	</PropertyGroup>	
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />

--- a/NuGet/Cotecna.Domain.Core.Configuration/Cotecna.Domain.Core.Configuration.csproj
+++ b/NuGet/Cotecna.Domain.Core.Configuration/Cotecna.Domain.Core.Configuration.csproj
@@ -26,7 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/NuGet/Cotecna.Domain.Core.Configuration/changelog.md
+++ b/NuGet/Cotecna.Domain.Core.Configuration/changelog.md
@@ -6,9 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Releases]
 
-## [4.0.0] - 2024-12-19
+## [4.0.0] - 2025-01-15
 ### Removed
 - .NET 6 Support (https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/)
+
+
+## [3.1.0] - 2024-11-13
+### Added
+- Supports .NET 9
+
 
 ## [3.0.0] - 2024-09-09
 ### Removed

--- a/NuGet/Cotecna.Domain.Core.Configuration/changelog.md
+++ b/NuGet/Cotecna.Domain.Core.Configuration/changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Releases]
 
+## [4.0.0] - 2024-12-19
+### Removed
+- .NET 6 Support (https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/)
+
 ## [3.0.0] - 2024-09-09
 ### Removed
 - .NET 7 Support (https://devblogs.microsoft.com/dotnet/dotnet-7-end-of-support/)

--- a/NuGet/Cotecna.Domain.Core.Configuration/changelog.md
+++ b/NuGet/Cotecna.Domain.Core.Configuration/changelog.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Releases]
 
-## [4.0.0] - 2025-01-15
+## [4.0.0] - 2025-02-27
 ### Removed
 - .NET 6 Support (https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/)
+
+### Changed
+ - Updates Dependencies for .NET 9
 
 
 ## [3.1.0] - 2024-11-13

--- a/NuGet/Cotecna.Domain.Core.Test/Cotecna.Domain.Core.Test.csproj
+++ b/NuGet/Cotecna.Domain.Core.Test/Cotecna.Domain.Core.Test.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuGet/Cotecna.Domain.Core.Test/Cotecna.Domain.Core.Test.csproj
+++ b/NuGet/Cotecna.Domain.Core.Test/Cotecna.Domain.Core.Test.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuGet/Cotecna.Domain.Core.Test/Cotecna.Domain.Core.Test.csproj
+++ b/NuGet/Cotecna.Domain.Core.Test/Cotecna.Domain.Core.Test.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuGet/Cotecna.Domain.Core.Test/Cotecna.Domain.Core.Test.csproj
+++ b/NuGet/Cotecna.Domain.Core.Test/Cotecna.Domain.Core.Test.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuGet/Cotecna.Domain.Core/Cotecna.Domain.Core.csproj
+++ b/NuGet/Cotecna.Domain.Core/Cotecna.Domain.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<PackageId>Cotecna.Domain.Core</PackageId>
 		<AssemblyName>Cotecna.Domain.Core</AssemblyName>
 		<RootNamespace>Cotecna.Domain.Core</RootNamespace>
@@ -10,9 +10,9 @@
 		<Authors>Cotecna Inspection</Authors>
 		<Company>Cotecna Inspection</Company>
 		<RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-		<Version>3.1.0</Version>
-		<FileVersion>3.1.0</FileVersion>
-		<AssemblyVersion>3.1.0</AssemblyVersion>
+		<Version>4.0.0</Version>
+		<FileVersion>4.0.0</FileVersion>
+		<AssemblyVersion>4.0.0</AssemblyVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageProjectUrl>https://github.com/Cotecna-Inspection/Domain.Core</PackageProjectUrl>
 		<PackageReleaseNotes>https://github.com/Cotecna-Inspection/Domain.Core/blob/main/NuGet/Cotecna.Domain.Core/changelog.md</PackageReleaseNotes>

--- a/NuGet/Cotecna.Domain.Core/changelog.md
+++ b/NuGet/Cotecna.Domain.Core/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Releases]
 
+## [4.0.0] - 2025-01-15
+### Removed
+- .NET 6 Support (https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/)
+
+
 ## [3.1.0] - 2024-11-13
 ### Added
 - Supports .NET 9

--- a/NuGet/Cotecna.Domain.Core/changelog.md
+++ b/NuGet/Cotecna.Domain.Core/changelog.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Releases]
 
-## [4.0.0] - 2025-01-15
+## [4.0.0] - 2025-02-27
 ### Removed
 - .NET 6 Support (https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/)
+
+### Changed
+ - Updates Dependecies for .NET 9
 
 
 ## [3.1.0] - 2024-11-13

--- a/NuGet/Cotecna.Domain.Core/changelog.md
+++ b/NuGet/Cotecna.Domain.Core/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .NET 6 Support (https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/)
 
 ### Changed
- - Updates Dependecies for .NET 9
+ - Updates Dependencies for .NET 9
 
 
 ## [3.1.0] - 2024-11-13

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The intention of the project is to create code without third-party dependencies,
 ![Nuget](https://img.shields.io/nuget/v/Cotecna.Domain.Core?label=Cotecna.Domain.Core&style=for-the-badge) ![Nuget](https://img.shields.io/nuget/v/Cotecna.Domain.Core.Configuration?label=Cotecna.Domain.Core.Configuration&style=for-the-badge)
 
 Target frameworks:
-- .NET 6.0
+- .NET 3.1 (Obsolete)
+- .NET 5.0 (Obsolete)
+- .NET 6.0 (Obsolete)
 - .NET 8.0
 - .NET 9.0
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ The intention of the project is to create code without third-party dependencies,
 ![Nuget](https://img.shields.io/nuget/v/Cotecna.Domain.Core?label=Cotecna.Domain.Core&style=for-the-badge) ![Nuget](https://img.shields.io/nuget/v/Cotecna.Domain.Core.Configuration?label=Cotecna.Domain.Core.Configuration&style=for-the-badge)
 
 Target frameworks:
-- .NET 3.1 (Obsolete)
-- .NET 5.0 (Obsolete)
-- .NET 6.0 (Obsolete)
 - .NET 8.0
 - .NET 9.0
 


### PR DESCRIPTION
- NET 6 Reached End Of Support on November 12. It will not receive any Security Updates